### PR TITLE
Accessibility Plugin: Fix overview mode

### DIFF
--- a/class1.html
+++ b/class1.html
@@ -310,7 +310,7 @@
 
       // Full list of configuration options available here:
       // https://github.com/hakimel/reveal.js#configuration
-            Reveal.initialize({
+      Reveal.initialize({
         controls: true,
         progress: true,
         history: true,
@@ -326,7 +326,7 @@
           { src: 'plugin/highlight/highlight.js', async: true, condition: function() { return !!document.querySelector( 'pre code' ); }, callback: function() { hljs.initHighlightingOnLoad(); } },
           { src: 'plugin/zoom-js/zoom.js', async: true },
           { src: 'plugin/notes/notes.js', async: true },
-                    { src: 'plugin/accessibility-helper/js/accessibility-helper.js', async: true, condition: function() { return !!document.body.classList; } }
+          { src: 'plugin/accessibility-helper/js/accessibility-helper.js', async: true, condition: function() { return !!document.body.classList; } }
         ]
       });
 

--- a/class2.html
+++ b/class2.html
@@ -321,7 +321,7 @@ Copied from HTML5 Boilerplate*/
 
       // Full list of configuration options available here:
       // https://github.com/hakimel/reveal.js#configuration
-            Reveal.initialize({
+      Reveal.initialize({
         controls: true,
         progress: true,
         history: true,
@@ -337,7 +337,7 @@ Copied from HTML5 Boilerplate*/
           { src: 'plugin/highlight/highlight.js', async: true, condition: function() { return !!document.querySelector( 'pre code' ); }, callback: function() { hljs.initHighlightingOnLoad(); } },
           { src: 'plugin/zoom-js/zoom.js', async: true },
           { src: 'plugin/notes/notes.js', async: true },
-                    { src: 'plugin/accessibility-helper/js/accessibility-helper.js', async: true, condition: function() { return !!document.body.classList; } }
+          { src: 'plugin/accessibility-helper/js/accessibility-helper.js', async: true, condition: function() { return !!document.body.classList; } }
         ]
       });
 

--- a/plugin/accessibility-helper/css/accessibility-helper.css
+++ b/plugin/accessibility-helper/css/accessibility-helper.css
@@ -14,7 +14,11 @@
   display: none;
   visibility: hidden;
 }
-
+.reveal.overview .slides>section>.accessibilityWrapper,
+.reveal.overview .slides>section>section>.accessibilityWrapper {
+  display: block;
+  visibility: visible;
+}
 .reveal .slides section.present > .accessibilityWrapper {
   display: block;
   visibility: visible;

--- a/plugin/accessibility-helper/js/accessibility-helper.js
+++ b/plugin/accessibility-helper/js/accessibility-helper.js
@@ -4,8 +4,6 @@
  * The default CSS and JavaScript of Reveal.js has poor keyboard and screen reader
  * accessibility because slides are not fully hidden after animating. This plugin wraps slide
  * contents in an element that can be hidden with CSS and not affect slide transitions.
- * It requires the 'linear' transition to effectively move between slides when CSS is
- * applied.
  *
  * It also includes an auto-generated skip links plugin.
  *


### PR DESCRIPTION
This update fixes a bug where formerly-offscreen slides are still hidden after triggering overview mode in Reveal.js by hitting the ESC key. :tada: